### PR TITLE
chore: update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Update GitHub Actions to versions compatible with Node 24:

- `actions/checkout@v4` -> `actions/checkout@v6`
- `actions/setup-python@v5` -> `actions/setup-python@v6`

## Files Changed

- `.github/workflows/ci.yml`